### PR TITLE
Password length requirement is too long.

### DIFF
--- a/BuildFeed/Models/ViewModel/ChangePassword.cs
+++ b/BuildFeed/Models/ViewModel/ChangePassword.cs
@@ -10,17 +10,17 @@ namespace BuildFeed.Models.ViewModel
     public class ChangePassword
     {
         [Required]
-        [MinLength(12)]
+        [MinLength(8)]
         [DisplayName("Enter current password")]
         public string OldPassword { get; set; }
 
         [Required]
-        [MinLength(12)]
+        [MinLength(8)]
         [DisplayName("Enter new password")]
         public string NewPassword { get; set; }
 
         [Required]
-        [MinLength(12)]
+        [MinLength(8)]
         [DisplayName("Confirm new password")]
         [Compare("NewPassword")]
         public string ConfirmNewPassword { get; set; }

--- a/BuildFeed/Models/ViewModel/RegistrationUser.cs
+++ b/BuildFeed/Models/ViewModel/RegistrationUser.cs
@@ -14,12 +14,12 @@ namespace BuildFeed.Models.ViewModel
         public string UserName { get; set; }
 
         [Required]
-        [MinLength(12)]
+        [MinLength(8)]
         [DisplayName("Enter password")]
         public string Password { get; set; }
 
         [Required]
-        [MinLength(12)]
+        [MinLength(8)]
         [DisplayName("Confirm password")]
         [Compare("Password")]
         public string ConfirmPassword { get; set; }

--- a/RedisAuth/RedisMembershipProvider.cs
+++ b/RedisAuth/RedisMembershipProvider.cs
@@ -16,9 +16,9 @@ namespace RedisAuth
     public class RedisMembershipProvider : MembershipProvider
     {
         private bool _enablePasswordReset = true;
-        private int _maxInvalidPasswordAttempts = 5;
+        private int _maxInvalidPasswordAttempts = 3;
         private int _minRequiredNonAlphanumericCharacters = 1;
-        private int _minRequriedPasswordLength = 12;
+        private int _minRequriedPasswordLength = 8;
         private int _passwordAttemptWindow = 60;
         private bool _requiresUniqueEmail = true;
 


### PR DESCRIPTION
Drop password length requirement down from 12 characters to a min of 8.
This will cause user frustration as not everyone has long passwords.

Drop max password entries from 5 to 3. 
If you can't remember your password after 3 tries, just reset it, it's easier.