### PR TITLE
Remove the 'medium' flight for the (win10) builds ...

### DIFF
--- a/BuildFeed/Models/Build.cs
+++ b/BuildFeed/Models/Build.cs
@@ -301,9 +301,6 @@ namespace BuildFeed.Models
         [Display(ResourceType = typeof(Model), Name = "FlightLow")]
         Low = 1,
 
-        [Display(ResourceType = typeof(Model), Name = "FlightMedium")]
-        Medium = 2,
-
         [Display(ResourceType = typeof(Model), Name = "FlightHigh")]
         High = 3
     }

--- a/BuildFeed/Views/support/rss.cshtml
+++ b/BuildFeed/Views/support/rss.cshtml
@@ -13,7 +13,6 @@
         @BuildFeed.Local.Model.FlightLevel
         <ul>
             <li><a href="@Url.Action("flight", new { controller = "rss", id = "low" })" title="@BuildFeed.Local.Model.FlightLow"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightLow</a></li>
-            <li><a href="@Url.Action("flight", new { controller = "rss", id = "medium" })" title="@BuildFeed.Local.Model.FlightMedium"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightMedium</a></li>
             <li><a href="@Url.Action("flight", new { controller = "rss", id = "high" })" title="@BuildFeed.Local.Model.FlightHigh"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightHigh</a></li>
         </ul>
     </li>

--- a/BuildFeed/Views/support/sitemap.cshtml
+++ b/BuildFeed/Views/support/sitemap.cshtml
@@ -74,7 +74,6 @@
                         @BuildFeed.Local.Model.FlightLevel
                         <ul>
                             <li><a href="@Url.Action("flight", new { controller = "rss", id = "low" })" title="@BuildFeed.Local.Model.FlightLow"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightLow</a></li>
-                            <li><a href="@Url.Action("flight", new { controller = "rss", id = "medium" })" title="@BuildFeed.Local.Model.FlightMedium"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightMedium</a></li>
                             <li><a href="@Url.Action("flight", new { controller = "rss", id = "high" })" title="@BuildFeed.Local.Model.FlightHigh"><i class="fa fa-sm fa-rss"></i> @BuildFeed.Local.Model.FlightHigh</a></li>
                         </ul>
                     </li>


### PR DESCRIPTION
Since we don't have (correctly) documented any 'medium' flight build (https://buildfeed.net/rss/flight/medium/) it's better to remove it from the website.